### PR TITLE
Release/v1.0.3

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GithubSharedProjectSettings">
+    <option name="branchProtectionPatterns">
+      <list>
+        <option value="master" />
+      </list>
+    </option>
+  </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
   </component>

--- a/highlight/build.gradle
+++ b/highlight/build.gradle
@@ -10,7 +10,7 @@ android {
         minSdk 21
         targetSdk 31
         versionCode 3
-        versionName "1.0.2"
+        versionName "1.0.3"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -48,7 +48,7 @@ afterEvaluate {
                 // You can then customize attributes of the publication as shown below.
                 groupId = 'com.github.Irineu333'
                 artifactId = 'highlight'
-                version = '1.0.2'
+                version = '1.0.3'
             }
         }
     }


### PR DESCRIPTION
feat : add scheme scope

Each scheme has a scope, which is the region it highlights, and other schemes can be added to its scope and only process within that scope.